### PR TITLE
feat: if there is only one model do not prompt user

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,143 @@
+use std::error::Error;
+use git2::Repository;
+
+pub mod providers;
+pub mod git_analysis;
+pub mod git;
+pub mod ui;
+pub mod modes;
+
+#[derive(Debug)]
+pub struct Config {
+    model: Box<dyn git_analysis::GitAnalyzer>,
+    repo_path: String,
+}
+
+#[derive(Debug)]
+pub struct FileAnalysis {
+    pub path: String,
+    pub explanation: String,
+}
+
+impl Config {
+    pub fn new(model: Box<dyn git_analysis::GitAnalyzer>, repo_path: Option<String>) -> Self {
+        Self { 
+            model,
+            repo_path: repo_path.unwrap_or_else(|| ".".to_string())
+        }
+    }
+
+    pub fn with_new_model(self, model: Box<dyn git_analysis::GitAnalyzer>) -> Self {
+        Self {
+            model,
+            repo_path: self.repo_path,
+        }
+    }
+
+    pub fn with_new_repo(self, repo_path: String) -> Self {
+        Self {
+            model: self.model,
+            repo_path,
+        }
+    }
+
+    pub async fn generate_commit_message(&self, diff: &str) -> Result<String, Box<dyn Error>> {
+        self.model.generate_commit_message(diff).await
+    }
+
+    pub async fn analyze_changes(&self, repo: &Repository) -> Result<Vec<FileAnalysis>, Box<dyn Error>> {
+        let file_diffs = git::get_file_diffs(repo)?;
+        
+        let analysis_futures: Vec<_> = file_diffs.into_iter().map(|(path, diff)| {
+            let model = &self.model;
+            async move {
+                let explanation = model.analyze_file_changes(&diff).await?;
+                Ok::<FileAnalysis, Box<dyn Error>>(FileAnalysis {
+                    path,
+                    explanation,
+                })
+            }
+        }).collect();
+
+        futures::future::join_all(analysis_futures)
+            .await
+            .into_iter()
+            .collect()
+    }
+
+    pub async fn analyze_contributor(&self, stats: &str) -> Result<String, Box<dyn Error>> {
+        self.model.analyze_contributor(stats).await
+    }
+}
+
+pub async fn run(_repo_path: Option<String>) -> Result<(), Box<dyn Error>> {
+    let repo_path = loop {
+        let path = ui::get_repository_path(".")?;
+        match Repository::open(&path) {
+            Ok(_) => break path,
+            Err(_) => println!("Invalid git repository path. Please try again."),
+        }
+    };
+
+    let mut config = {
+        let providers = providers::get_available_providers();
+        let selected_idx = providers::select_provider(&providers)?;
+        if providers.len() == 1 {
+            println!("Using {} as the only available AI model", providers[0].name());
+        }
+        Config::new(git_analysis::wrap_provider(providers.into_iter().nth(selected_idx).unwrap()), Some(repo_path))
+    };
+    
+    let mut repo = Repository::open(&config.repo_path)?;
+
+    loop {
+        let mode = ui::select_mode().await?;
+        mode.execute(&config, &repo).await?;
+
+        // Determine available options based on number of providers
+        let providers = providers::get_available_providers();
+        let options = if providers.len() > 1 {
+            vec!["✨ Do something else", "🤖 Switch AI model", "📁 Switch repository", "❌ Exit"]
+        } else {
+            vec!["✨ Do something else", "📁 Switch repository", "❌ Exit"]
+        };
+
+        match ui::show_selection_menu("What would you like to do next?", &options, 0)? {
+            0 => (),  // Continue loop
+            1 if providers.len() > 1 => {
+                let selected_idx = providers::select_provider(&providers)?;
+                config = config.with_new_model(git_analysis::wrap_provider(providers.into_iter().nth(selected_idx).unwrap()));
+            }
+            1 => { // Repository switch when only one provider
+                let new_path = loop {
+                    let path = ui::get_repository_path(".")?;
+                    match Repository::open(&path) {
+                        Ok(new_repo) => {
+                            repo = new_repo;
+                            break path;
+                        }
+                        Err(_) => println!("Invalid git repository path. Please try again."),
+                    }
+                };
+                config = config.with_new_repo(new_path);
+            }
+            2 if providers.len() > 1 => { // Repository switch when multiple providers
+                let new_path = loop {
+                    let path = ui::get_repository_path(".")?;
+                    match Repository::open(&path) {
+                        Ok(new_repo) => {
+                            repo = new_repo;
+                            break path;
+                        }
+                        Err(_) => println!("Invalid git repository path. Please try again."),
+                    }
+                };
+                config = config.with_new_repo(new_path);
+            }
+            _ => break,
+        }
+        println!("\x1B[2J\x1B[1;1H"); // Clear screen
+    }
+    
+    Ok(())
+} 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,0 +1,103 @@
+use async_trait::async_trait;
+use std::error::Error;
+use std::fmt::Debug;
+use dialoguer::{theme::ColorfulTheme, Select};
+
+pub mod openai;
+pub mod claude;
+pub mod gemini;
+pub mod deepseek;
+
+pub use openai::OpenAIProvider;
+pub use claude::ClaudeProvider;
+pub use gemini::GeminiProvider;
+pub use deepseek::DeepSeekProvider;
+
+/// Base trait for AI model providers with general capabilities
+#[async_trait]
+pub trait Provider: Send + Sync + Debug {
+    fn name(&self) -> &str;
+    
+    /// Generate text based on a system prompt and user input
+    async fn generate_text(
+        &self,
+        system_prompt: &str,
+        user_input: &str,
+        temperature: f32,
+    ) -> Result<String, Box<dyn Error>>;
+}
+
+/// Error type for provider selection
+#[derive(Debug)]
+pub enum ProviderError {
+    NoProvidersAvailable,
+    InvalidSelection,
+}
+
+impl std::fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoProvidersAvailable => write!(f, "No AI providers available"),
+            Self::InvalidSelection => write!(f, "Invalid provider selection"),
+        }
+    }
+}
+
+impl Error for ProviderError {}
+
+/// Get all available providers based on environment variables
+pub fn get_available_providers() -> Vec<Box<dyn Provider>> {
+    use std::env;
+
+    let mut providers = Vec::new();
+    
+    if env::var("OPENAI_API_KEY").is_ok() {
+        providers.push(Box::new(OpenAIProvider::new()) as Box<dyn Provider>);
+    }
+    
+    if env::var("ANTHROPIC_API_KEY").is_ok() {
+        providers.push(Box::new(ClaudeProvider::new()) as Box<dyn Provider>);
+    }
+    
+    if env::var("DEEPSEEK_API_KEY").is_ok() {
+        providers.push(Box::new(DeepSeekProvider::new()) as Box<dyn Provider>);
+    }
+    
+    if env::var("GEMINI_API_KEY").is_ok() {
+        providers.push(Box::new(GeminiProvider::new()) as Box<dyn Provider>);
+    }
+
+    if providers.is_empty() {
+        eprintln!("No AI providers found. Please set at least one API key:");
+        eprintln!("  OPENAI_API_KEY for OpenAI");
+        eprintln!("  ANTHROPIC_API_KEY for Claude");
+        eprintln!("  DEEPSEEK_API_KEY for DeepSeek");
+        eprintln!("  GEMINI_API_KEY for Google");
+        std::process::exit(1);
+    }
+    
+    providers
+}
+
+/// Select a provider from the available ones
+pub fn select_provider(providers: &[Box<dyn Provider>]) -> Result<usize, Box<dyn Error>> {
+    if providers.is_empty() {
+        return Err(Box::new(ProviderError::NoProvidersAvailable));
+    }
+
+    // If there's only one provider, automatically select it
+    if providers.len() == 1 {
+        return Ok(0);
+    }
+
+    let provider_names: Vec<String> = providers
+        .iter()
+        .map(|p| p.name().to_string())
+        .collect();
+
+    Ok(Select::with_theme(&ColorfulTheme::default())
+        .with_prompt("Select an AI model provider")
+        .items(&provider_names)
+        .default(0)
+        .interact()?)
+} 


### PR DESCRIPTION
If the user has only added one valid key in `.env`, automatically select that model for all tasks and disable the model switching command.